### PR TITLE
Add delay setting for hissing start

### DIFF
--- a/hiss_handler.py
+++ b/hiss_handler.py
@@ -161,6 +161,7 @@ class DelayedHissingJobHandler:
     def start_hiss_if_not_canceled(self):
         actions.user.fire_chicken_simulate_hissing_change()
         self.hiss_successfully_started = True
+        self.job = None
     
     def stop_delayed_hiss(self):
         self.cancel_job()


### PR DESCRIPTION
Add a delay setting for hissing start that requires you to hiss that amount before you are considered to have started hissing to reduce false positives. 